### PR TITLE
Add composer replace directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
             "email": "khaperets@gmail.com"
         }
     ],
+    "replace": {
+        "symfony-bundles/json-request-bundle": "3.1.1"
+    },
     "autoload": {
         "psr-4": {
             "SymfonyBundles\\JsonRequestBundle\\": ""


### PR DESCRIPTION
This would allow to use this repository whenever someone requires 'symfony-bundles/json-request-bundle' as a deeper level dependency